### PR TITLE
Add Github Workflow

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,0 +1,44 @@
+name: Build on Push
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v2
+      with:
+        node-version: '14'
+
+    - name: Install dependencies
+      run: npm install
+
+    - name: Build Strapi
+      run: npm run build
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: build-artifacts
+        path: build
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: build-artifacts
+
+      - name: Deploy to server
+        run: |
+          # Add your deployment commands here


### PR DESCRIPTION
1. Updated the GitHub Actions workflow to trigger on pushes to the master branch only.
2. Added a step to build the Strapi project using the npm run build command.
3. Modified the workflow to upload the build artifacts as an artifact named build-artifacts.
4. Added a placeholder deploy job to demonstrate the deployment step (deployment commands need to be added).